### PR TITLE
Update uniqueness on regexp_source + regexp_flag by category

### DIFF
--- a/backends/translation-web/core/models.py
+++ b/backends/translation-web/core/models.py
@@ -71,7 +71,7 @@ class Matcher(models.Model):
             # 2. raw 가 빈칸(즉 regex)인 경우,
             #    regexp_source + regexp_flag 쌍이 유일
             models.UniqueConstraint(
-                fields=["regexp_source", "regexp_flag"],
+                fields=["category", "regexp_source", "regexp_flag"],
                 condition=Q(raw=""),
                 name="uniq_regex_pair",
             ),


### PR DESCRIPTION
I would like to suggest to ease the uniqueness constraint "uniq_regex_pair" to include category as well, since I do not find it violating the translation logic when two or more identical pairs of regexp_source and regexp_flag when their categories are different. ([We always check the category before we try to match anything](https://github.com/refracta/dcss-webtiles-extension-module/blob/main/modules/translation-module/translator.js#L105-L106).)