### PR TITLE
Fix recoding typo

### DIFF
--- a/modules/advanced-watch/index.js
+++ b/modules/advanced-watch/index.js
@@ -2,7 +2,7 @@ export default class AdvancedWatch {
     static name = 'AdvancedWatch'
     static version = '0.1'
     static dependencies = ['IOHook']
-    static description = '(Beta) This module provides features for webtiles game recoding.'
+    static description = '(Beta) This module provides features for webtiles game recording.'
 
     onLoad() {
 

--- a/modules/wtrec/index.js
+++ b/modules/wtrec/index.js
@@ -4,7 +4,7 @@ export default class WTRec {
     static name = 'WTRec'
     static version = '0.1'
     static dependencies = ['IOHook']
-    static description = '(Beta) This module provides features for webtiles game recoding.'
+    static description = '(Beta) This module provides features for webtiles game recording.'
 
     async downloadWTRec() {
         const zip = new JSZip();


### PR DESCRIPTION
## Summary
- fix description typo in `advanced-watch` and `wtrec`

## Testing
- `grep -R "recoding" -n || true`