### PR TITLE
Fix josa pattern escape for untranslated groups

### DIFF
--- a/modules/translation-module/translator.js
+++ b/modules/translation-module/translator.js
@@ -141,6 +141,14 @@ export default class Translator {
                     }
                 }
                 if (!done) {
+                    let escaped = false;
+                    replaced = replaced.replace(/\{(.+?):([\p{L}\p{N}_]+)\}/gu, (match, paramsStr, funcName) => {
+                        if (paramsStr.includes(capture) && escaped === false) {
+                            escaped = true;
+                            return `{${paramsStr.replace(capture, capture.replace(/([\\{}:,])/g, '\\$1'))}:${funcName}}`;
+                        }
+                        return `{${paramsStr}:${funcName}}`;
+                    });
                     translations.push({target: capture, status: 'untranslated', totalStatus: 'untranslated'});
                 }
             }


### PR DESCRIPTION
## Summary
- handle untranslated captures inside josa patterns
  - when a capture is untranslated and appears inside `{...:func}` patterns, escape braces so that `replaceSpecialPattern` can process it later

## Testing
- `npm test` *(fails: Missing script)*